### PR TITLE
Out es ha support

### DIFF
--- a/plugins/out_es/es.h
+++ b/plugins/out_es/es.h
@@ -31,7 +31,7 @@
 #define FLB_ES_DEFAULT_TIME_KEYF  "%Y-%m-%dT%H:%M:%S"
 #define FLB_ES_DEFAULT_TAG_KEY    "flb-key"
 
-struct flb_elasticsearch {
+struct flb_elasticsearch_config {
     /* Elasticsearch index (database) and type (table) */
     char *index;
     char *type;
@@ -90,8 +90,19 @@ struct flb_elasticsearch {
     /* Elasticsearch HTTP API */
     char uri[256];
 
-    /* Upstream connection to the backend server */
+    /* Link to list flb_elasticsearch->configs */
+    struct mk_list _head;
+};
+
+struct flb_elasticsearch {
+    /* if HA mode is enabled */
+    int ha_mode;              /* High Availability mode enabled ? */
+    char *ha_upstream;        /* Upstream configuration file      */
+    struct flb_upstream_ha *ha;
+
+    /* Upstream handler and config context for single mode (no HA) */
     struct flb_upstream *u;
+    struct mk_list configs;
 };
 
 #endif

--- a/plugins/out_es/es_conf.h
+++ b/plugins/out_es/es_conf.h
@@ -27,8 +27,15 @@
 
 #include "es.h"
 
-struct flb_elasticsearch *flb_es_conf_create(struct flb_output_instance *ins,
-                                             struct flb_config *config);
-int flb_es_conf_destroy(struct flb_elasticsearch *ctx);
+
+int es_config_ha(const char *upstream_file,
+                        struct flb_elasticsearch *ctx,
+                        struct flb_config *config);
+
+int es_config_simple(struct flb_output_instance *ins,
+                          struct flb_elasticsearch *ctx,
+                          struct flb_config *config);
+
+int flb_es_conf_destroy(struct flb_elasticsearch_config *ec);
 
 #endif


### PR DESCRIPTION
When testing the out_es_ha_support branch I found two issues with it.

The first was a debug statement that caused a segfault when running without any upstream servers configuration. 

The other was an segfault at shutdown when using more than one upstream servers. The reason for this is that the flb_elasticsearch_config context was only allocated once and not for each of the nodes defined in the upstream servers definition.