### PR TITLE
Various fixes to adopt the out_es_ha_support branch for master

### DIFF
--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -624,14 +624,13 @@ static void cb_es_flush(const void *data, size_t bytes,
 
         /* Get forward_config stored in node opaque data */
         ec = flb_upstream_node_get_data(node);
+        flb_plg_debug(ctx->ins, "trying node %s", node->name);
     }
     else {
         ec = mk_list_entry_first(&ctx->configs,
                                  struct flb_elasticsearch_config,
                                  _head);
     }
-
-    flb_plg_debug(ctx->ins, "trying node %s", node->name);
 
     /* Get upstream connection */
     if (ctx->ha_mode == FLB_TRUE) {
@@ -904,6 +903,11 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_BOOL, "trace_error", "false",
      0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, trace_error),
+     NULL
+    },
+    {
+     FLB_CONFIG_MAP_STR, "upstream", NULL,
+     0, FLB_FALSE, 0,
      NULL
     },
 

--- a/plugins/out_es/es_conf.c
+++ b/plugins/out_es/es_conf.c
@@ -80,17 +80,20 @@ int es_config_ha(const char *upstream_file,
         }
 
         /* Set manual Index and Type */
-        if (f_index) {
-            ec->index = flb_strdup(f_index->value); /* FIXME */
+        tmp = flb_upstream_node_get_property("index", node);
+        if (tmp) {
+            ec->index = tmp;
         }
         else {
-            ec->index = flb_strdup(FLB_ES_DEFAULT_INDEX);
+            ec->index = FLB_ES_DEFAULT_INDEX;
         }
-        if (f_type) {
-            ec->type = flb_strdup(f_type->value); /* FIXME */
+
+        tmp = flb_upstream_node_get_property("type", node);
+        if (tmp) {
+            ec->type = tmp; 
         }
         else {
-            ec->type = flb_strdup(FLB_ES_DEFAULT_TYPE);
+            ec->type = FLB_ES_DEFAULT_TYPE;
         }
 
         /* HTTP Payload (response) maximum buffer size (0 == unlimited) */
@@ -131,7 +134,7 @@ int es_config_ha(const char *upstream_file,
                     flb_es_conf_destroy(ctx);
                     return NULL;
                 }
-                ec->aws_region = flb_strdup(tmp);
+                ec->aws_region = tmp; 
             }
         }
 #endif
@@ -215,15 +218,6 @@ int es_config_simple(struct flb_output_instance *ins,
     /* Set instance flags into upstream */
     flb_output_upstream_set(ctx->u, ins);
 
-    /* Set manual Index and Type */
-    if (f_index) {
-        ec->index = flb_strdup(f_index->value); /* FIXME */
-    }
-
-    if (f_type) {
-        ec->type = flb_strdup(f_type->value); /* FIXME */
-    }
-
     /* HTTP Payload (response) maximum buffer size (0 == unlimited) */
     if (ec->buffer_size == -1) {
         ec->buffer_size = 0;
@@ -262,7 +256,7 @@ int es_config_simple(struct flb_output_instance *ins,
                 flb_es_conf_destroy(ctx);
                 return NULL;
             }
-            ec->aws_region = flb_strdup(tmp);
+            ec->aws_region = tmp;
         }
     }
 #endif


### PR DESCRIPTION
Various fixes to be able to get the out_es_ha_support branch functional vs master.
It has been test both with and without upstream servers configuration.

There is a memory leak when running without upstream servers due to the ec->index and ec->type being flb_strdup'ed. Have not yet figured out how the cleanup can be made support both configurations. I hope that you might be able to help out here.